### PR TITLE
CRITICAL: Force ic0.app for mainnet by completely ignoring ICP_HOST e…

### DIFF
--- a/app/api/ops/debug/gateway/route.ts
+++ b/app/api/ops/debug/gateway/route.ts
@@ -6,18 +6,17 @@ export const fetchCache = 'force-no-store';
 
 export async function GET(req: NextRequest) {
   try {
-    const explicitHost = process.env.ICP_HOST || process.env.NEXT_PUBLIC_ICP_HOST;
     const isLocal = (process.env.DFX_NETWORK || '').toLowerCase() === 'local';
     const isMainnet = (process.env.DFX_NETWORK || 'ic').toLowerCase() === 'ic';
     const dfxNetwork = process.env.DFX_NETWORK || 'ic';
     
-    // This mirrors the logic in services/ops/icAgent.ts
-    let expectedHost = explicitHost || (isLocal ? 'http://127.0.0.1:4943' : (isMainnet ? 'https://ic0.app' : 'https://icp-api.io'));
+    // This mirrors the logic in services/ops/icAgent.ts - FORCE ic0.app for mainnet
+    let expectedHost = isLocal ? 'http://127.0.0.1:4943' : (isMainnet ? 'https://ic0.app' : 'https://icp-api.io');
     
     const res = NextResponse.json({
       ok: true,
       gateway: {
-        explicitHost: explicitHost || null,
+        explicitHost: 'FORCED_OVERRIDE',
         dfxNetwork,
         isLocal,
         isMainnet,

--- a/services/ops/icAgent.ts
+++ b/services/ops/icAgent.ts
@@ -3,12 +3,11 @@ import fetch from 'cross-fetch';
 
 // Generic actor factory using a provided idlFactory
 export async function getActor<T = Record<string, any>>(canisterId: string, idlFactory: any) {
-  const explicitHost = process.env.ICP_HOST || process.env.NEXT_PUBLIC_ICP_HOST;
   const isLocal = (process.env.DFX_NETWORK || '').toLowerCase() === 'local';
   const isMainnet = (process.env.DFX_NETWORK || 'ic').toLowerCase() === 'ic';
   
-  // Force ic0.app for mainnet to ensure query signatures are available
-  let host = explicitHost || (isLocal ? 'http://127.0.0.1:4943' : (isMainnet ? 'https://ic0.app' : 'https://icp-api.io'));
+  // Force ic0.app for mainnet to ensure query signatures are available (ignore env vars)
+  let host = isLocal ? 'http://127.0.0.1:4943' : (isMainnet ? 'https://ic0.app' : 'https://icp-api.io');
 
   // If attempting to use a local replica, probe reachability and fall back to mainnet gateway if unreachable
   if (host.includes('127.0.0.1') || host.includes('localhost')) {


### PR DESCRIPTION
…nv vars

Production was still using NEXT_PUBLIC_ICP_HOST=https://icp-api.io which overrode our hardcoded ic0.app logic. This fix completely ignores all ICP_HOST environment variables and forces https://ic0.app directly for mainnet.

Changes:
- Remove explicitHost logic that read env vars
- Force ic0.app directly when isMainnet=true
- Update debug endpoint to show FORCED_OVERRIDE
- This should finally resolve EVM canister query signature issues